### PR TITLE
Implement runtime check for toolbar modifier

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "NSToolbarHitTestingFix",
     platforms: [
-        .macOS(.v15)
+        .macOS(.v10_15)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A lightweight Swift package that installs a hit-testing workaround for toolbar r
 
 ## Usage
 
-Apply the `toolbarClickThrough()` modifier to any SwiftUI view that should forward interactions through the toolbar.
+Apply the `toolbarClickThrough()` modifier to any SwiftUI view that should forward interactions through the toolbar. On macOS versions earlier than 26, calling the modifier has no effect.
 
 ```swift
 Text("Hello")

--- a/Sources/NSToolbarHitTestingFix/NSToolbarHitTestingFix.swift
+++ b/Sources/NSToolbarHitTestingFix/NSToolbarHitTestingFix.swift
@@ -6,9 +6,13 @@ import AppKit
 // behind the toolbar.
 
 public extension View {
-    @available(macOS 26.0, *)
+    @ViewBuilder
     func toolbarClickThrough() -> some View {
-        modifier(ToolbarClickThroughModifier())
+        if #available(macOS 26.0, *) {
+            modifier(ToolbarClickThroughModifier())
+        } else {
+            self
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- support calling `toolbarClickThrough()` on all macOS versions
- update README to clarify behaviour

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685526ac44dc8325a6068fe4cc768e8c